### PR TITLE
Rename name field in parse results

### DIFF
--- a/db_manager.py
+++ b/db_manager.py
@@ -24,7 +24,7 @@ class ScrapedData(Base):
     __tablename__ = "scraped_data"
 
     id: int = Column(Integer, primary_key=True, autoincrement=True)
-    name: str = Column(String(255), nullable=False)
+    product_name: str = Column(String(255), nullable=False)
     url: str = Column(String(1024), nullable=False)
     scraped_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
 
@@ -64,7 +64,7 @@ class DatabaseManager:
             df = pd.DataFrame([
                 {
                     "id": d.id,
-                    "name": d.name,
+                    "product_name": d.product_name,
                     "url": d.url,
                     "scraped_at": d.scraped_at,
                 }

--- a/scraper.py
+++ b/scraper.py
@@ -3,7 +3,7 @@
 核心爬蟲模組
 ===============================
 • 功能：下載並解析 https://yuyu-tei.jp/top/opc
-• 輸出：List[Dict[str, str]] -> [{"name": ..., "url": ...}, ...]
+• 輸出：List[Dict[str, str]] -> [{"product_name": ..., "url": ...}, ...]
 
 此模組僅專注『抓資料』，不負責資料庫或排程。
 """
@@ -78,7 +78,7 @@ class Scraper:
 
                 results.append(
                     {
-                        "name": btn.get_text(strip=True),
+                        "product_name": btn.get_text(strip=True),
                         "url": m.group(1),
                     }
                 )


### PR DESCRIPTION
## Summary
- change parse function to return `product_name` instead of `name`
- update ORM model and dataframe generation to use new field

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684af98f1fbc832393b1c852668fb42a