### PR TITLE
Implement improved card scraping

### DIFF
--- a/models.py
+++ b/models.py
@@ -14,6 +14,7 @@ class Card:
 
     name: str
     rarity: str
+    url: str
     image: str
     number: str
     price: int


### PR DESCRIPTION
## Summary
- follow each card link and parse details from its page
- add `parse_card_page` helper for card info extraction

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c23f927788323acac0e7d95c63b32