### PR TITLE
Remove fallback quantity parsing

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -111,11 +111,6 @@ class Scraper:
                             except ValueError:
                                 quantity = 0
 
-        if quantity == 0:
-            text = soup.get_text(" ", strip=True)
-            qty_match = re.search(r"(\d+)\s*\D*在庫", text)
-            if qty_match:
-                quantity = int(qty_match.group(1))
 
         return Card(
             name="",


### PR DESCRIPTION
## Summary
- simplify `parse_card_page` by removing fallback quantity lookup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c45a2522c832384bd14827b1b98d9