### PR TITLE
Add scraped_at timestamp to Card

### DIFF
--- a/models.py
+++ b/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import List
 
 __all__ = ["Card", "Product"]
@@ -19,6 +20,7 @@ class Card:
     number: str
     price: int
     quantity: int
+    scraped_at: datetime
     feature: str = ""
     color: str = ""
 

--- a/scraper.py
+++ b/scraper.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import re
 from typing import List
+from datetime import datetime
 
 from models import Product, Card
 
@@ -132,6 +133,7 @@ class Scraper:
             number=number,
             price=price,
             quantity=quantity,
+            scraped_at=datetime.utcnow(),
             feature=feature,
             color=color,
         )


### PR DESCRIPTION
## Summary
- add `scraped_at` field to `Card` dataclass
- fill `scraped_at` with current UTC time when parsing card page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cd6d9343883238bbbcc2faface463