### PR TITLE
Restrict scraped_at to date only

### DIFF
--- a/db_manager.py
+++ b/db_manager.py
@@ -8,7 +8,7 @@ separate table ``CardPrice``. Other card information is stored once in
 """
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date
 from typing import List
 
 from sqlalchemy import (
@@ -16,7 +16,7 @@ from sqlalchemy import (
     Column,
     Integer,
     String,
-    DateTime,
+    Date,
     LargeBinary,
     ForeignKey,
     UniqueConstraint,
@@ -68,7 +68,7 @@ class CardPrice(Base):
     card_id: int = Column(Integer, ForeignKey("card.id"), nullable=False)
     price: int = Column(Integer, nullable=False)
     quantity: int = Column(Integer, nullable=False)
-    scraped_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
+    scraped_at: date = Column(Date, default=date.today, nullable=False)
 
 
 class DatabaseManager:

--- a/models.py
+++ b/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import date
 from typing import List
 
 __all__ = ["Card", "Product"]
@@ -20,7 +20,7 @@ class Card:
     number: str
     price: int
     quantity: int
-    scraped_at: datetime
+    scraped_at: date
     feature: str = ""
     color: str = ""
 

--- a/scraper.py
+++ b/scraper.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import re
 from typing import List
-from datetime import datetime
+from datetime import date
 
 from models import Product, Card
 
@@ -135,7 +135,7 @@ class Scraper:
             number=number,
             price=price,
             quantity=quantity,
-            scraped_at=datetime.utcnow(),
+            scraped_at=date.today(),
             feature=feature,
             color=color,
         )


### PR DESCRIPTION
## Summary
- adjust `Card.scraped_at` to store `date`
- use `date.today()` when scraping
- update SQLAlchemy model `CardPrice.scraped_at` to `Date`
- keep functionality otherwise the same

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d3ad2ad808323879488d61c43e6aa