### PR TITLE
Fix GUI layout and default size

### DIFF
--- a/gui_app.py
+++ b/gui_app.py
@@ -61,6 +61,7 @@ class StatsWindow(QMainWindow):
         self.db_path = db_path
         self.db = DatabaseManager(db_path=db_path)
         self.setWindowTitle("Card Price Stats")
+        self.resize(1000, 600)
 
         self.figure, self.ax = plt.subplots()
         self.canvas = FigureCanvas(self.figure)
@@ -106,11 +107,13 @@ class StatsWindow(QMainWindow):
         filter_row3.addWidget(self.plot_btn)
 
         central = QWidget()
-        layout = QVBoxLayout(central)
-        layout.addLayout(filter_row1)
-        layout.addLayout(filter_row2)
-        layout.addLayout(filter_row3)
-        layout.addWidget(self.canvas)
+        main_layout = QHBoxLayout(central)
+        filters_layout = QVBoxLayout()
+        filters_layout.addLayout(filter_row1)
+        filters_layout.addLayout(filter_row2)
+        filters_layout.addLayout(filter_row3)
+        main_layout.addLayout(filters_layout)
+        main_layout.addWidget(self.canvas)
         self.setCentralWidget(central)
 
         self.df: pd.DataFrame = pd.DataFrame()


### PR DESCRIPTION
## Summary
- resize the main window to have greater width
- arrange filter widgets in a vertical sidebar on the left
- display plot to the right of the filters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ebd26074483238319700616e27a05